### PR TITLE
Convert DWORD to DWORD_PTR as appropriate for 64-bit Windows compile.

### DIFF
--- a/src/adpcm.cpp
+++ b/src/adpcm.cpp
@@ -22,10 +22,10 @@ BYTE* Adpcm::waveToAdpcm(void *pData,DWORD dSize,DWORD &dAdpcmSize,DWORD dRate,D
 		return NULL;
 	}
 	// 先頭チャンクを設定
-	pChunk = reinterpret_cast<CHUNK_HED*>(reinterpret_cast<DWORD>(pChunk) + 4);
+	pChunk = reinterpret_cast<CHUNK_HED*>(reinterpret_cast<DWORD_PTR>(pChunk) + 4);
 	m_pWaveChunk = NULL;
 	m_pDataChunk = NULL;
-	while(reinterpret_cast<DWORD>(pChunk) < reinterpret_cast<DWORD>(pData) + dSize)
+	while(reinterpret_cast<DWORD_PTR>(pChunk) < reinterpret_cast<DWORD_PTR>(pData) + dSize)
 	{
 		// fmtチャンクの場合
 		if(pChunk->bID[0] == 'f' && pChunk->bID[1] == 'm' && pChunk->bID[2] == 't' && pChunk->bID[3] == ' '){
@@ -38,7 +38,7 @@ BYTE* Adpcm::waveToAdpcm(void *pData,DWORD dSize,DWORD &dAdpcmSize,DWORD dRate,D
 			m_pDataChunk = reinterpret_cast<DATA_CHUNK*>(pChunk);
 		}
 		// 次のチャンクへアドレスを加算する
-		pChunk = reinterpret_cast<CHUNK_HED*>(reinterpret_cast<DWORD>(pChunk) + pChunk->dChunkSize + 8);
+		pChunk = reinterpret_cast<CHUNK_HED*>(reinterpret_cast<DWORD_PTR>(pChunk) + pChunk->dChunkSize + 8);
 	}
 	// fmtチャンク及びdataチャンクが存在するか
 	if(m_pWaveChunk == NULL || m_pDataChunk == NULL){
@@ -170,7 +170,7 @@ int Adpcm::encode(short *pSrc,unsigned char *pDis,DWORD iSampleSize){
 	// 初期値設定
 	xn			= 0;
 	stepSize	= 127;
-	
+
 	for( iCnt = 0 ; iCnt < static_cast<int>(iSampleSize) ; iCnt++ ){
 		// エンコード処理
 		dn = *pSrc - xn;		// 差分抽出
@@ -204,4 +204,3 @@ int Adpcm::encode(short *pSrc,unsigned char *pDis,DWORD iSampleSize){
 	}
 	return 0;
 }
-


### PR DESCRIPTION
It's been a while, hasn't it? :)

These are type changes to make `mucom88` compile on 64-bit Windows. It is a continuation of PR #9.