### PR TITLE
Fix compilation on linux #18 - pull request from gzaffin

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ CC = gcc
 CFLAGS = 
 CXXFLAGS = 
 # CXXFLAGS += -Wno-write-strings
-COMMON_FLAGS =
+COMMON_FLAGS = -Wall -O3
 # COMMON_FLAGS += -Wall -Werror
 LDFLAGS = 
 DEFINES = 
@@ -37,8 +37,8 @@ TARGET_PCMTOOL = pcmtool$(EXE_SUFFIX)
 
 ifeq ($(DEBUG),1)
 TARGET = $(TARGET_NAME)_d$(EXE_SUFFIX)
-LDFLAGS += -g
-COMMON_FLAGS += -O0 -g
+LDFLAGS = -g
+COMMON_FLAGS = -O0 -g -Wall
 OBJS_DIR = objs_d
 endif
 
@@ -115,13 +115,22 @@ DEP_SRCS += sdl/osdep_sdl.cpp
 DEP_SRCS += sdl/audiobuffer.cpp
 DEP_SRCS += sdl/audiotime.cpp
 
-SDL_CFLAGS = $(shell sdl-config --cflags) -DUSE_SDL
+SDL_CFLAGS = `sdl-config --cflags` -DUSE_SDL
 COMMON_FLAGS += $(SDL_CFLAGS)
 
 ifeq ($(STATIC),1)
-SDL_LIBS =  $(shell sdl-config --static-libs)
+ifeq ($(OS_LINUX),1)
+SDL_LIBS =  `sdl-config --static-libs` -static-libgcc -static-libstdc++
+LDFLAGS +=  -Wl,-rpath,/usr/local/lib,-rpath,/usr/lib/x86_64-linux-gnu,-rpath,/usr/lib/gcc/x86_64-linux-gnu
 else
-SDL_LIBS =  $(shell sdl-config --libs)
+SDL_LIBS =  `sdl-config --static-libs`
+endif
+else
+ifeq ($(OS_LINUX),1)
+SDL_LIBS =  `sdl-config --libs` -lX11
+else 
+SDL_LIBS =  `sdl-config --libs`
+endif
 endif
 
 ifeq ($(SDL_WIN32),1)

--- a/src/Makefile.setting
+++ b/src/Makefile.setting
@@ -29,4 +29,12 @@ endif
 endif
 
 # static
+ifeq ($(WIN32),1)
 STATIC = 1
+endif
+ifeq ($(OS_OSX),1)
+STATIC = 1
+endif
+ifeq ($(OS_LINUX),1)
+STATIC = 0
+endif

--- a/src/adpcm.h
+++ b/src/adpcm.h
@@ -15,6 +15,11 @@ typedef unsigned long DWORD;
 typedef unsigned short WORD;
 #endif
 
+#ifndef _WIN32
+typedef unsigned long ULONG_PTR;
+typedef ULONG_PTR DWORD_PTR;
+#endif
+
 typedef struct {
 	BYTE	bID[4];		// ヘッダ
 	DWORD	dSize;		// サイズ

--- a/src/sdl/osdep_sdl.cpp
+++ b/src/sdl/osdep_sdl.cpp
@@ -184,7 +184,7 @@ bool OsDependentSdl::InitTimer() {
 }
 
 void OsDependentSdl::FreeTimer() {
-    SDL_RemoveTimer((SDL_TimerID)TimerId);
+    SDL_RemoveTimer(TimerId);
 }
 
 // オーディオ更新用タイマー

--- a/src/sdl/osdep_sdl.h
+++ b/src/sdl/osdep_sdl.h
@@ -4,7 +4,7 @@
 #ifndef _OS_DEP_SDL_H_
 #define _OS_DEP_SDL_H_
 
-
+#include <SDL.h>
 #include <stdint.h>
 #include "../osdep.h"
 #include "audiotime.h"
@@ -69,7 +69,7 @@ public:
     bool AudioOpenFlag;
 
 private:
-	void *TimerId;
+	SDL_TimerID TimerId;
 };
 
 #endif


### PR DESCRIPTION
I didn't noticed GNU/Linux static linking problem because I always swap SDL1.2 with SDL2.
My proposed patch uses dynamic linking for GNU/Linux and it keeps SDL1.2.